### PR TITLE
Fix mobx-react and mobx-react-versions

### DIFF
--- a/eslint-config/index.js
+++ b/eslint-config/index.js
@@ -23,6 +23,7 @@ module.exports = {
     'react/prop-types': 'off',
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
+    'react/no-unescaped-entities': 'warn',
     '@typescript-eslint/no-unused-vars': 'error',
     //'@typescript-eslint/interface-name-prefix': ['error', { prefixWithI: 'always' }],
     '@typescript-eslint/explicit-function-return-type': ['warn', { allowExpressions: true }],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mediafellows/mfx-ui-dependencies",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mediafellows/mfx-ui-dependencies",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },
@@ -85,7 +85,8 @@
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.10.3",
-    "mobx-react": "6.3.0",
+    "mobx-react": "6.2.2",
+    "mobx-react-lite": "2.0.7",
     "classnames": "^2.2.5",
     "colors": "^1.1.2",
     "cookies-js": "^1.2.3",


### PR DESCRIPTION
Fix 74581 for front-ends.
This PR also has a missed commit for disable error in unescaped entities in html texts - this was intended for v24, but was missed somehow.

Current v24 was released on same master as v23, so now v25 is correct